### PR TITLE
Colocate GCP compute instance with the SQL instance

### DIFF
--- a/terraform/concourse-gcp/inputs.tf
+++ b/terraform/concourse-gcp/inputs.tf
@@ -15,9 +15,9 @@ variable "internal_cidr" {
 }
 
 variable "zone" {
-  default = "europe-north2-a"
+  default = "europe-west4-b"
 }
 
 variable "region" {
-  default = "europe-north2"
+  default = "europe-west4"
 }


### PR DESCRIPTION
Our GCP compute instances are located in `europe-west2` region when the GCP SQL instance is located in `europe-west4` which generated "Network Inter Region Data Transfer Out from Netherlands to London" ~700$ per month. We should recreate the compute instances in the SQL instance region which shouldn't be an issue to avoid those costs. As a next step we could decide to move all together to a cheaper GCP region.