### PR TITLE
fix: Adjust the auth permission handling for the database approvers

### DIFF
--- a/bosh-deploy-concourse/vars.yml
+++ b/bosh-deploy-concourse/vars.yml
@@ -10,15 +10,19 @@ main_team.auth_config: |
   roles:
   - name: owner
     github:
-      orgs: ["cloudfoundry:wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-approvers"]
+      teams: 
+      - "cloudfoundry:wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-approvers"
     local:
       users: ["ci-user"]
+  - name: member
+    github:
+      teams: 
+      - "cloudfoundry:wg-foundational-infrastructure-integrated-databases-mysql-postgres-approvers"
   - name: viewer
     github:
-      orgs:
+      teams:
       - "cloudfoundry:wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-reviewers"
       - "cloudfoundry:wg-foundational-infrastructure-integrated-databases-mysql-postgres-reviewers"
-      - "cloudfoundry:wg-foundational-infrastructure-integrated-databases-mysql-postgres-approvers"
 max_containers: 1000
 network_name: default
 postgres_host: ((postgres_host))


### PR DESCRIPTION
# Update Concourse auth configuration

## Changes
- Restructured GitHub authentication configuration in `vars.yml`
- Changed from using `orgs` to `teams` for more granular access control as documented [here](https://concourse-ci.org/managing-teams.html#setting-roles)
- Added new [member](https://concourse-ci.org/user-roles.html#team-member-role) role for database approvers
- Reorganized viewer permissions

## Details
- Owner role:
  - Changed from organization-based to team-based access
  - Maintained access for BOSH approvers
  - Kept local ci-user access unchanged
- Added new member role:
  - Granted access to database approvers team
- Viewer role:
  - Changed from organization to team-based access
  - Includes BOSH reviewers and database reviewers
  - Moved database approvers to member role for more appropriate access level

## Impact
This change provides a more structured and granular access control system for the Concourse deployment, better aligning team permissions with their responsibilities.

## Future Optimization Potential: Team Separation

Moving the pipelines into dedicated [Concourse teams](https://concourse-ci.org/managing-teams.html#fly-set-team) could provide several benefits for access management and resource isolation. Currently, all pipelines run in the main team, but splitting them based on their purpose (e.g., separate teams for BOSH, databases, and other components) would allow for more precise access control and better resource management. Each team could have its own set of credentials and secrets, reducing the blast radius of potential issues. This separation would also enable more granular permissions, where team members would only have access to the pipelines relevant to their work. For example, database maintainers would only see and manage database-related pipelines, while BOSH maintainers would focus on BOSH pipelines. This approach aligns with the principle of least privilege and could improve both security and operational clarity. The topic needs to be discussed with the community.