### PR TITLE
Configure clean up policy to stemcell buckets

### DIFF
--- a/utils/add-clean-up-lifecycle-policy-to-buckets
+++ b/utils/add-clean-up-lifecycle-policy-to-buckets
@@ -2,12 +2,13 @@
 set -euo pipefail
 
 # List of buckets to update
-BUCKETS="bosh-core-stemcells bosh-core-stemcells-fips bosh-core-stemcells-candidate bosh-core-stemcells-candidate-fips"
+RELEASE_BUCKETS="bosh-core-stemcells bosh-core-stemcells-fips"
+CANDIDATE_BUCKETS="bosh-core-stemcells-candidate bosh-core-stemcells-candidate-fips"
 
-for bucket_name in $BUCKETS; do
+for bucket_name in $RELEASE_BUCKETS; do
     echo "Setting lifecycle policy for bucket: $bucket_name"
-    gcloud storage buckets update "$bucket_name" \
-      --lifecycle-file=<(cat <<EOF
+    tmpfile=$(mktemp)
+    cat <<EOF > "$tmpfile"
 {
   "rule": [
     {
@@ -17,7 +18,25 @@ for bucket_name in $BUCKETS; do
   ]
 }
 EOF
-)
+    gcloud storage buckets update "gs://$bucket_name" --lifecycle-file="$tmpfile"
+    rm -f "$tmpfile"
+done
+
+for bucket_name in $CANDIDATE_BUCKETS; do
+  echo "Setting lifecycle policy for bucket: $bucket_name"
+    tmpfile=$(mktemp)
+    cat <<EOF > "$tmpfile"
+{
+  "rule": [
+    {
+      "action": {"type": "Delete"},
+      "condition": {"age": 365}
+    }
+  ]
+}
+EOF
+    gcloud storage buckets update "gs://$bucket_name" --lifecycle-file="$tmpfile"
+    rm -f "$tmpfile"
 done
 
 echo "Done."


### PR DESCRIPTION
This script will delete buckets older than 3 years as agreed in [this RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0010-stemcell-cleanup.md). Additionally, it configures deletion also for candidate stemcell buckets from one year.