### PR TITLE
Add containerd allowed devices

### DIFF
--- a/bosh-deploy-concourse/worker-container-overrides.yml
+++ b/bosh-deploy-concourse/worker-container-overrides.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=worker/jobs/name=worker/properties/containerd/allowed_devices?
+  path: /instance_groups/name=worker/jobs/name=worker/properties/containerd?/allowed_devices?
   value:
     - b 7:* rwm
     - b 252:* rwm
@@ -7,10 +7,10 @@
     - c 10:237 rwm
 
 - type: replace
-  path: /instance_groups/name=worker/jobs/name=worker/properties/containerd/dns_servers
+  path: /instance_groups/name=worker/jobs/name=worker/properties/containerd?/dns_servers
   value:
     - ((containerd_dns_servers))
 
 - type: replace
-  path: /instance_groups/name=worker/jobs/name=worker/properties/containerd/max_containers
+  path: /instance_groups/name=worker/jobs/name=worker/properties/containerd?/max_containers
   value: ((max_containers))


### PR DESCRIPTION
Fixes:
```
Could not interpolate: Error 'operation [0] in /tmp/build/put/concourse-infra-for-fiwg/bosh-deploy-concourse/worker-container-overrides.yml failed': Expected to find a map key 'containerd' for path '/instance_groups/name=worker/jobs/name=worker/properties/containerd' (found map keys: 'baggageclaim', 'drain_timeout', 'worker_gateway')
```