### PR TITLE
Disable AppArmor unprivileged userns restriction on workers

### DIFF
--- a/bosh-deploy-concourse/worker-sysctl.yml
+++ b/bosh-deploy-concourse/worker-sysctl.yml
@@ -1,0 +1,14 @@
+- type: replace
+  path: /releases/-
+  value:
+    name: os-conf
+    version: latest
+
+- type: replace
+  path: /instance_groups/name=worker/jobs/-
+  value:
+    name: sysctl
+    release: os-conf
+    properties:
+      sysctl:
+        - kernel.apparmor_restrict_unprivileged_userns=0

--- a/ci/pipelines/deploy-concourse.yml
+++ b/ci/pipelines/deploy-concourse.yml
@@ -380,6 +380,7 @@ jobs:
           trigger: true
           passed:
             - create-director
+        - get: os-conf-release
         - get: uaa-bosh-release
       - in_parallel:
         - do:
@@ -433,11 +434,13 @@ jobs:
             - concourse-infra-for-fiwg/bosh-deploy-concourse/uaa-uses-internal-ip.yml
             - concourse-infra-for-fiwg/bosh-deploy-concourse/update-sections.yml
             - concourse-infra-for-fiwg/bosh-deploy-concourse/web-lb-extension.yml
+            - concourse-infra-for-fiwg/bosh-deploy-concourse/worker-sysctl.yml
             - concourse-infra-for-fiwg/bosh-deploy-concourse/update-variables-for-upgrader.yml
             releases:
             - bpm-bosh-release/release.tgz
             - concourse-bosh-release/release.tgz
             - credhub-bosh-release/release.tgz
+            - os-conf-release/release.tgz
             - uaa-bosh-release/release.tgz
             stemcells:
             - gcp-stemcell/stemcell.tgz
@@ -486,6 +489,10 @@ jobs:
           trigger: true
           passed:
           - bosh-deploy-upgrader-concourse
+        - get: os-conf-release
+          tags: [upgrader]
+          passed:
+          - bosh-deploy-upgrader-concourse
         - get: uaa-bosh-release
           tags: [upgrader]
           passed:
@@ -525,10 +532,12 @@ jobs:
             - concourse-infra-for-fiwg/bosh-deploy-concourse/uaa-uses-internal-ip.yml
             - concourse-infra-for-fiwg/bosh-deploy-concourse/update-sections.yml
             - concourse-infra-for-fiwg/bosh-deploy-concourse/web-lb-extension.yml
+            - concourse-infra-for-fiwg/bosh-deploy-concourse/worker-sysctl.yml
           releases:
             - bpm-bosh-release/release.tgz
             - concourse-bosh-release/release.tgz
             - credhub-bosh-release/release.tgz
+            - os-conf-release/release.tgz
             - uaa-bosh-release/release.tgz
           stemcells:
             - gcp-stemcell/stemcell.tgz


### PR DESCRIPTION
After upgrading Concourse workers from Ubuntu Jammy to Noble, heavy stemcell deploys on
AWS began failing with:
```
sudo: /etc/sudo.conf is owned by uid 65534, should be 0 
sudo: /usr/libexec/sudo/sudoers.so must be owned by uid 0 
sudo: fatal error, unable to load plugins
```

Noble enables `kernel.apparmor_restrict_unprivileged_userns=1` by default, which
restricts capabilities within unprivileged user namespaces. This causes unmapped UIDs to
fall back to 65534 (nobody) during the stemcell build, corrupting ownership of files that
were not explicitly chowned.

## Summary
- Adds a new ops file (`worker-sysctl.yml`) that colocates the `sysctl` job
  from `os-conf-release` on the worker instance group, setting
  `kernel.apparmor_restrict_unprivileged_userns=0`
- Wires `os-conf-release` into both the upgrader and main Concourse
  deployment jobs in the pipeline

## Context
Ubuntu Noble enables `kernel.apparmor_restrict_unprivileged_userns` by
default, which prevents unprivileged processes from creating user
namespaces. This breaks container workloads on Concourse workers that
rely on unprivileged user namespace creation. The sysctl is applied
during BOSH pre-start, before the worker process comes up.
