### PR TITLE
Add TOC to docs CI team

### DIFF
--- a/ci/teams/wg-docs.yml
+++ b/ci/teams/wg-docs.yml
@@ -3,5 +3,6 @@ roles:
     github:
       teams:
       - cloudfoundry:wg-documentation-docs-approvers
+      - cloudfoundry:toc
     local:
       users: ["ci-user"]


### PR DESCRIPTION
- To help assist docs writers with any pipeline issues