### PR TITLE
CI: use registry-image type

### DIFF
--- a/ci/pipelines/deploy-concourse.yml
+++ b/ci/pipelines/deploy-concourse.yml
@@ -5,11 +5,11 @@ stemcell_vars: &stemcell_vars
   stemcell_os: ubuntu-noble
 resource_types:
   - name: bosh-deployment
-    type: docker-image
+    type: registry-image
     source:
       repository: cloudfoundry/bosh-deployment-resource
   - name: gcs-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: frodenas/gcs-resource
       username: ((dockerhub_username))


### PR DESCRIPTION
NOTE: pipeline is already re-configured

The latests version of concourse is unable to load `type: docker-image` in most cases.

Should address:
```
failed to fetch manifest: Head "https://registry-1.docker.io/v2 ..
```
^ https://bosh.ci.cloudfoundry.org/teams/main/pipelines/deploy-concourse/jobs/regenerate-certs/builds/43#L69b9f9ba/image-check:2