### PR TITLE
CI: Switch worker baggageclaim driver from btrfs to overlay

### DIFF
--- a/bosh-deploy-concourse/vars.yml
+++ b/bosh-deploy-concourse/vars.yml
@@ -26,7 +26,7 @@ postgres_password: ((postgres_concourse_user.password))
 postgres_port: 5432
 postgres_role: ((postgres_concourse_user.username))
 postgres_ca_cert: ((postgres_ca.certificate))
-storage_driver: btrfs
+storage_driver: overlay
 tls_port: 443
 uaa_db_password: ((postgres_uaa_user.password))
 web_vm_extension: concourse-web

--- a/ci/pipelines/deploy-concourse.yml
+++ b/ci/pipelines/deploy-concourse.yml
@@ -437,7 +437,7 @@ jobs:
             - gcp-stemcell/stemcell.tgz
             vars:
               deployment_name: concourse-upgrader
-              storage_driver: btrfs
+              storage_driver: overlay
               web_instances: 1
               web_ip: 10.0.0.50
               web_vm_type: concourse_web
@@ -524,7 +524,7 @@ jobs:
             - gcp-stemcell/stemcell.tgz
           vars:
             deployment_name: concourse
-            storage_driver: btrfs
+            storage_driver: overlay
             upgrader_web_ip: 10.0.0.50
             web_instances: 1
             web_ip: 10.0.0.4


### PR DESCRIPTION
The btrfs driver relies on a loopback device that leaks on unclean worker restarts (the likely cause of the recurring `stalled` workers), and overlay is now the upstream-preferred default. It may also fix the uid drift where non-root users (uid 1001) end up owning `$HOME` as uid 1002/1003, breaking tasks with `Permission denied`.
Ref: https://github.com/concourse/concourse/issues/8226

## Change

`storage_driver: btrfs` → `overlay` in `vars.yml` and both deploy jobs in `deploy-concourse.yml`.

## Migration steps

1. Set the pipeline with the change and let the deploy jobs run (lands the `baggageclaim.driver: overlay` property).
2. Recreate the workers so they come up with clean disks (a plain redeploy leaves the old btrfs loopback in place):
  Workers have no persistent disk and update at `max_in_flight: 50%`, so half the fleet keeps serving builds during the recreate.
